### PR TITLE
always use excerpt until more-tag

### DIFF
--- a/cat-posts.php
+++ b/cat-posts.php
@@ -130,7 +130,10 @@ class CategoryPosts extends WP_Widget {
 				<?php endif; ?>
 							
 				<?php if ( isset( $instance['excerpt'] ) ) : ?>
-				<?php the_excerpt(); ?> 
+				<?php 
+					global $more; 
+					$more = 0;    
+					the_content('read more…'); ?> 
 				<?php endif; ?>
 				
 				<?php if ( isset( $instance['comment_num'] ) ) : ?>


### PR DESCRIPTION
This fixed the problem that the widget didn't display the post only until the more-tag while wordpress displayed a full article.