### PR TITLE
Add a css class, if current single Post is displayed

### DIFF
--- a/cat-posts.php
+++ b/cat-posts.php
@@ -109,7 +109,11 @@ class CategoryPosts extends WP_Widget {
 			$cat_posts->the_post();
 		?>
 			<li class="cat-post-item">
-				<a class="post-title" href="<?php the_permalink(); ?>" rel="bookmark" title="Permanent link to <?php the_title_attribute(); ?>"><?php the_title(); ?></a>
+				<?php if ( !is_single( get_the_title() ) ) : ?>
+					<a class="post-title" href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a>
+				<?php else : ?>
+					<a class="post-title current-post" href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a>
+				<?php endif; ?>
 				
 
 				<?php if ( isset( $instance['date'] ) ) : ?>


### PR DESCRIPTION
If a post is displayed as a single Post a css class is added to the cat-posts widget menu, as is often done in the main menu ("current-menu-item" "current_page_item", etc). Now you can make a css select to .current-post{ font-weight: bold; }