### PR TITLE
Fixed a typo

### DIFF
--- a/cat-posts.php
+++ b/cat-posts.php
@@ -198,7 +198,7 @@ class CategoryPosts extends WP_Widget {
 			// Footer link to category page
 			if( isset ( $instance["footer_link"] ) ) {
 				echo "<a";
-					if( !isset( $instance['disable_css'] ) ) { echo " class:\"cat-post-footer-link\""; }
+					if( !isset( $instance['disable_css'] ) ) { echo " class=\"cat-post-footer-link\""; }
 				echo " href=\"" . get_category_link($instance["cat"]) . "\">" . $instance["footer_link"] . "</a>";
 			}
 


### PR DESCRIPTION
On the post footer link, the html was using class:" instead of class=".
Thanks for the useful plugin!